### PR TITLE
Implement shorter function syntax.

### DIFF
--- a/site/fizz-language-reference.md
+++ b/site/fizz-language-reference.md
@@ -11,14 +11,15 @@ nav_order: 2
 
 ### define
 
-`(define <name> <value>)`
+Values - `(define <name> <value>)`
+Functions - `(define (<name> <args...>) <expr>...)`
 
 Define a value within the current module that can be referenced.
 
 ```lisp
 >> (define x 12)
->> (define square
->>   (lambda (x) (* x x)))
+>> (define (square x)
+>>   (* x x))
 >> (square x)
 $1 = 144
 ```
@@ -27,12 +28,12 @@ $1 = 144
 
 `(lambda (<args...>) <exprs...>)`
 
-Lambda is used to define a function.
+Define a function.
 
 ```lisp
 >> (define my-plus-func (lambda (a b) (+ a b)))
 >> my-plus-func
-$1 = <function >
+$1 = <function _>
 >> (my-plus-func 2 2)
 $2 = 4
 >> ((lambda (a b) (- a b)) 2 2)

--- a/site/index.md
+++ b/site/index.md
@@ -69,7 +69,7 @@ It should be easy to get started writing Fizz. Fizz supports the following:
  > ```lisp
  > >> (define pi 3.14)
  > >> (* 2 pi) ;; 6.28
- > >> (define plus (lambda (a b) (+ a b)))
+ > >> (define (plus a b) (+ a b))
  > >> (plus 2 2) ;; 4
  > >> (if (< 1 2) "red" "blue") ;; "red"
  > ```

--- a/src/Vm.zig
+++ b/src/Vm.zig
@@ -111,7 +111,7 @@ pub fn toZig(self: *Vm, T: type, alloc: std.mem.Allocator, val: Val) !T {
             }
         },
         .Struct => |info| {
-            const map = switch (val) {
+            const struct_val = switch (val) {
                 .structV => |m| m,
                 else => return error.TypeError,
             };
@@ -128,7 +128,7 @@ pub fn toZig(self: *Vm, T: type, alloc: std.mem.Allocator, val: Val) !T {
                 @memcpy(&fizz_field_name, field.name);
                 makeKebabCase(&fizz_field_name);
                 if (self.env.memory_manager.symbols.getId(&fizz_field_name)) |sym| {
-                    const field_val = map.get(sym) orelse
+                    const field_val = struct_val.map.get(sym) orelse
                         return Error.TypeError;
                     const field_zig_val = try self.toZig(field.type, alloc, field_val);
                     errdefer toZigClean(field.type, alloc, field_zig_val, null);

--- a/src/golden_test.fizz
+++ b/src/golden_test.fizz
@@ -51,14 +51,13 @@ test-struct
 
 "------------------------------------------------------------"
 "test fib"
-(define fib
-  (lambda (n)
-    (define too-small? (< n 2))
-    (if too-small? n
-      (do
-        (define fib-1 (fib (- n 1)))
-	(define fib-2 (fib (- n 2)))
-	(+ fib-1 fib-2)))))
+(define (fib n)
+  (define too-small? (< n 2))
+  (if too-small? n
+    (do
+      (define fib-1 (fib (- n 1)))
+      (define fib-2 (fib (- n 2)))
+      (+ fib-1 fib-2))))
 fib
 (fib 25)
 

--- a/src/val.zig
+++ b/src/val.zig
@@ -11,13 +11,20 @@ pub const Val = union(enum) {
     string: []const u8,
     symbol: Symbol,
     list: []Val,
-    structV: *std.AutoHashMapUnmanaged(Symbol, Val),
+    structV: *StructVal,
     bytecode: *ByteCode,
     native_fn: NativeFn,
 
     const Tag = std.meta.Tag(Val);
 
     pub const Symbol = struct { id: usize };
+
+    pub const StructVal = struct {
+        map: std.AutoHashMapUnmanaged(Symbol, Val),
+        pub fn deinit(self: *StructVal, allocator: std.mem.Allocator) void {
+            self.map.deinit(allocator);
+        }
+    };
 
     pub const NativeFn = struct {
         pub const Error = error{
@@ -66,7 +73,7 @@ pub const Val = union(enum) {
                     try writer.writeAll(")");
                 },
                 .structV => |struct_map| {
-                    var iter = struct_map.iterator();
+                    var iter = struct_map.map.iterator();
                     try writer.writeAll("(struct");
                     while (iter.next()) |v| {
                         try writer.writeAll(" ");


### PR DESCRIPTION
Instead of:

```lisp
(define square (lambda (x) (* x x)))
```

Users can now write:

```lisp
(define (square x) (* x x))
```